### PR TITLE
Add orbital module buttons

### DIFF
--- a/Ascension/AscensionHomeView.swift
+++ b/Ascension/AscensionHomeView.swift
@@ -35,20 +35,16 @@ struct AscensionHomeView: View {
 
                 // 3. Orbiting modules
                 ForEach(modules) { module in
-                    Button {
-                        print("\(module.name) tapped")
-                    } label: {
-                        Circle()
-                            .fill(Color.white.opacity(module.active ? 0.2 : 0.08))
-                            .frame(width: 70, height: 70)
-                            .overlay(
-                                Circle()
-                                    .stroke(module.active ? Color.orange : Color.clear, lineWidth: 3)
-                            )
-                            .overlay(
-                                Image(systemName: module.systemImage)
-                                    .foregroundColor(.white.opacity(module.active ? 1 : 0.5))
-                            )
+                    ModuleButtonView(
+                        icon: module.systemImage,
+                        label: module.name,
+                        active: module.active
+                    ) {
+                        if module.active {
+                            print("\(module.name) launched")
+                        } else {
+                            print("Locked")
+                        }
                     }
                     .offset(
                         x: radius * cos(module.angle),

--- a/Ascension/ModuleButtonView.swift
+++ b/Ascension/ModuleButtonView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct ModuleButtonView: View {
+    var icon: String
+    var label: String
+    var active: Bool
+    var action: () -> Void
+
+    @State private var pressed = false
+
+    var body: some View {
+        Button {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                pressed = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                pressed = false
+            }
+            action()
+        } label: {
+            VStack(spacing: 4) {
+                Circle()
+                    .fill(Color.white.opacity(active ? 0.2 : 0.08))
+                    .frame(width: 70, height: 70)
+                    .overlay(
+                        Circle()
+                            .stroke(active ? Color.orange : Color.gray.opacity(0.4), lineWidth: 3)
+                            .shadow(color: active ? Color.orange.opacity(0.6) : Color.clear, radius: active ? 6 : 0)
+                    )
+                    .overlay(
+                        Image(systemName: icon)
+                            .foregroundColor(.white.opacity(active ? 1 : 0.5))
+                    )
+                    .scaleEffect(pressed ? 0.9 : 1.0)
+                Text(label)
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(active ? 0.9 : 0.6))
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    ModuleButtonView(icon: "tray.full", label: "Arkheion", active: true) {}
+}


### PR DESCRIPTION
## Summary
- create `ModuleButtonView` for reusable circular module buttons with optional label
- update `AscensionHomeView` to use `ModuleButtonView` for Arkheion, Lightborne, and Vanguard modules

## Testing
- `swift --version`
- `swiftc -o /tmp/testModuleButton Ascension/ModuleButtonView.swift` *(fails: no such module 'SwiftUI')*
- `xcodebuild -list -project Ascension.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68686e6d42e8832f9feec802e867b599