### PR TITLE
Add glowing HeartSunView

### DIFF
--- a/Ascension/AscensionHomeView.swift
+++ b/Ascension/AscensionHomeView.swift
@@ -53,20 +53,10 @@ struct AscensionHomeView: View {
                 }
 
                 // 2. Heart Sun
-                ZStack {
-                    Circle()
-                        .fill(Color.orange.opacity(0.9))
-                        .frame(width: 120, height: 120)
-                        .shadow(color: Color.orange.opacity(0.4), radius: 40)
-
-                    Circle()
-                        .stroke(Color.orange.opacity(0.6), lineWidth: 6)
-                        .frame(width: 140, height: 140)
-                        .blur(radius: 2)
-                }
-                .onTapGesture {
-                    print("Arkheion Launched")
-                }
+                HeartSunView()
+                    .onTapGesture {
+                        print("Arkheion Launched")
+                    }
 
                 // 4. ARC sigil
                 Image(systemName: "a.circle")

--- a/Ascension/HeartSunView.swift
+++ b/Ascension/HeartSunView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct HeartSunView: View {
+    @State private var animateGlow = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.orange.opacity(0.9))
+                .frame(width: 120, height: 120)
+                .shadow(color: Color.orange.opacity(0.4), radius: 40)
+
+            Circle()
+                .stroke(Color.orange.opacity(0.6), lineWidth: 6)
+                .frame(width: 140, height: 140)
+                .blur(radius: 2)
+                .scaleEffect(animateGlow ? 1.2 : 1.0)
+                .opacity(animateGlow ? 0.0 : 0.4)
+                .animation(
+                    .easeOut(duration: 3)
+                        .repeatForever(autoreverses: false),
+                    value: animateGlow
+                )
+        }
+        .onAppear {
+            animateGlow = true
+        }
+    }
+}
+
+#Preview {
+    HeartSunView()
+}


### PR DESCRIPTION
## Summary
- encapsulate heart sun logic in new `HeartSunView`
- add warm glowing animation around the heart sun
- use `HeartSunView` from `AscensionHomeView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868710cb3e8832fa5125ffcc048df6b