### PR TITLE
Fix macOS fullScreenCover issue

### DIFF
--- a/Ascension/AscensionHomeView.swift
+++ b/Ascension/AscensionHomeView.swift
@@ -92,11 +92,20 @@ struct AscensionHomeView: View {
                     .padding([.top, .leading, .trailing], 20)
             }
         }
+#if os(macOS)
+        .sheet(isPresented: $showArkheionMap) {
+            NavigationStack {
+                ArkheionMapView()
+            }
+            .frame(minWidth: 600, minHeight: 400)
+        }
+#else
         .fullScreenCover(isPresented: $showArkheionMap) {
             NavigationStack {
                 ArkheionMapView()
             }
         }
+#endif
     }
 
     private var headerAlignment: Alignment {


### PR DESCRIPTION
## Summary
- add a macOS-specific sheet for showing ArkheionMapView

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686875be4300832f9e14c9105710bb4d