### PR TITLE
Add persistence to NodeEditView

### DIFF
--- a/Ascension/NodeEditView.swift
+++ b/Ascension/NodeEditView.swift
@@ -85,6 +85,7 @@ struct NodeEditView: View {
         let trimmedQuote = quote.trimmingCharacters(in: .whitespacesAndNewlines)
         let updated = ArkheionNode(id: nodeID, title: trimmedTitle, archetype: archetype, type: type, prompt: trimmedPrompt, quote: trimmedQuote.isEmpty ? nil : trimmedQuote, status: status)
         progressModel.updateNode(updated)
+        Task { await progressModel.save() }
         dismiss()
     }
 }


### PR DESCRIPTION
## Summary
- ensure NodeEditView saves changes via `ArkheionProgressModel.save()`

## Testing
- `swiftc -parse Ascension/NodeEditView.swift`

------
https://chatgpt.com/codex/tasks/task_e_68687d58ab68832f89ee75b654dfc4b1