### PR TITLE
Fix HeartSun glow offset

### DIFF
--- a/Ascension/HeartSunView.swift
+++ b/Ascension/HeartSunView.swift
@@ -14,11 +14,11 @@ struct HeartSunView: View {
                 .stroke(Color.orange.opacity(0.6), lineWidth: 6)
                 .frame(width: 140, height: 140)
                 .blur(radius: 2)
-                .scaleEffect(animateGlow ? 1.2 : 1.0)
+                .scaleEffect(animateGlow ? 1.2 : 1.0, anchor: .center)
                 .opacity(animateGlow ? 0.0 : 0.4)
                 .animation(
                     .easeOut(duration: 3)
-                        .repeatForever(autoreverses: false),
+                        .repeatForever(autoreverses: true),
                     value: animateGlow
                 )
         }


### PR DESCRIPTION
## Summary
- keep the HeartSun glow centered by anchoring the scaling
- let the glow pulse by repeating the animation

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686880dbb15c832fb8dd6ffebc1490ac