### PR TITLE
Refactor sun glow logic

### DIFF
--- a/Ascension/ArkheionMapView.swift
+++ b/Ascension/ArkheionMapView.swift
@@ -302,17 +302,7 @@ private struct RootNodeView: View {
 
 private struct HeartSun: View {
     var body: some View {
-        ZStack {
-            Circle()
-                .fill(Color.orange.opacity(0.9))
-                .frame(width: 120, height: 120)
-                .shadow(color: Color.orange.opacity(0.4), radius: 40)
-
-            Circle()
-                .stroke(Color.orange.opacity(0.6), lineWidth: 6)
-                .frame(width: 140, height: 140)
-                .blur(radius: 2)
-        }
+        GlowingSunView(animated: false)
     }
 }
 

--- a/Ascension/GlowingSunView.swift
+++ b/Ascension/GlowingSunView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct GlowingSunView: View {
+    var color: Color = .orange
+    var baseSize: CGFloat = 120
+    var glowRadius: CGFloat = 40
+    var lineWidth: CGFloat = 6
+    var animated: Bool = true
+    var animationDuration: Double = 3
+
+    @State private var pulse = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(color.opacity(0.9))
+                .frame(width: baseSize, height: baseSize)
+                .shadow(color: color.opacity(0.4), radius: glowRadius)
+
+            Circle()
+                .stroke(color.opacity(0.6), lineWidth: lineWidth)
+                .frame(width: baseSize * 1.2, height: baseSize * 1.2)
+                .blur(radius: 2)
+                .scaleEffect(animated ? (pulse ? 1.3 : 1.0) : 1.0)
+                .opacity(animated ? (pulse ? 0.0 : 0.4) : 0.4)
+        }
+        .onAppear {
+            guard animated else { return }
+            withAnimation(
+                .easeOut(duration: animationDuration)
+                    .repeatForever(autoreverses: true)
+            ) {
+                pulse = true
+            }
+        }
+    }
+}
+
+#Preview {
+    GlowingSunView()
+}

--- a/Ascension/HeartSunView.swift
+++ b/Ascension/HeartSunView.swift
@@ -1,30 +1,8 @@
 import SwiftUI
 
 struct HeartSunView: View {
-    @State private var animateGlow = false
-
     var body: some View {
-        ZStack {
-            Circle()
-                .fill(Color.orange.opacity(0.9))
-                .frame(width: 120, height: 120)
-                .shadow(color: Color.orange.opacity(0.4), radius: 40)
-
-            Circle()
-                .stroke(Color.orange.opacity(0.6), lineWidth: 6)
-                .frame(width: 140, height: 140)
-                .blur(radius: 2)
-                .scaleEffect(animateGlow ? 1.2 : 1.0, anchor: .center)
-                .opacity(animateGlow ? 0.0 : 0.4)
-                .animation(
-                    .easeOut(duration: 3)
-                        .repeatForever(autoreverses: true),
-                    value: animateGlow
-                )
-        }
-        .onAppear {
-            animateGlow = true
-        }
+        GlowingSunView()
     }
 }
 


### PR DESCRIPTION
## Summary
- factor out glowing sun behavior into new `GlowingSunView`
- use `GlowingSunView` for `HeartSunView`
- update map view to reuse glowing sun without animation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686886631074832f8e64c06c1468ca37