### PR TITLE
Fix NodeConnectorView ForEach ID keypath

### DIFF
--- a/Ascension/NodeConnectorView.swift
+++ b/Ascension/NodeConnectorView.swift
@@ -19,7 +19,7 @@ struct NodeConnectorView: View {
             let radius = min(size.width, size.height) / 2
             let centerLocal = CGPoint(x: size.width / 2, y: size.height / 2)
 
-            ForEach(0..<8, id: .self) { index in
+            ForEach(0..<8, id: \.self) { index in
                 let angle = Double(index) * .pi / 4
                 let offset = CGSize(width: radius * cos(angle),
                                     height: radius * sin(angle))


### PR DESCRIPTION
## Summary
- fix `ForEach` ID keypath by adding missing backslash

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68696c5c3394832f968a65e4bf4922b1