### PR TITLE
Fix safeAreaInsets inference

### DIFF
--- a/Ascension/ArkheionMapView.swift
+++ b/Ascension/ArkheionMapView.swift
@@ -3,7 +3,9 @@ import SwiftUI
 struct ArkheionMapView: View {
     @EnvironmentObject private var progressModel: ArkheionProgressModel
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.safeAreaInsets) private var safeInsets
+    // Explicitly type the `safeAreaInsets` environment value to avoid generic
+    // inference issues when compiling on older SDKs.
+    @Environment(\.safeAreaInsets) private var safeInsets: EdgeInsets
     @State private var editNode: ArkheionNode?
     @State private var createNodeArchetype: String?
     @State private var selectedArchetype: String = "Scholar"

--- a/Ascension/RadialNavMenu.swift
+++ b/Ascension/RadialNavMenu.swift
@@ -7,7 +7,9 @@ struct RadialNavMenuItem: Identifiable {
 }
 
 struct RadialNavMenu: View {
-    @Environment(\.safeAreaInsets) private var safeAreaInsets
+    // Explicitly specify the type for the `safeAreaInsets` environment value
+    // so the compiler can resolve the generic parameter on all supported SDKs.
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
     var items: [RadialNavMenuItem]
     @State private var show = false
 


### PR DESCRIPTION
## Summary
- specify `EdgeInsets` type for `safeAreaInsets` environment value in `ArkheionMapView` and `RadialNavMenu`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686974883528832f8389167726777a6e