### PR TITLE
Ensure map view opens full screen on macOS

### DIFF
--- a/Ascension/Core/AscensionApp.swift
+++ b/Ascension/Core/AscensionApp.swift
@@ -31,5 +31,15 @@ struct AscensionApp: App {
                 .environmentObject(progressModel)
         }
         .modelContainer(sharedModelContainer)
+
+#if os(macOS)
+        WindowGroup(id: "ArkheionMap") {
+            NavigationStack {
+                ArkheionMapView()
+            }
+            .environmentObject(progressModel)
+        }
+        .modelContainer(sharedModelContainer)
+#endif
     }
 }

--- a/Ascension/Core/AscensionHomeView.swift
+++ b/Ascension/Core/AscensionHomeView.swift
@@ -122,15 +122,21 @@ extension View {
         isPresented: Binding<Bool>,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View {
-        if #available(macOS 13.0, *) {
-            fullScreenCover(isPresented: isPresented, content: content)
-        } else {
-            sheet(isPresented: isPresented) {
-                content()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .ignoresSafeArea()
+        modifier(MacMapPresenter(isPresented: isPresented))
+    }
+}
+
+private struct MacMapPresenter: ViewModifier {
+    @Binding var isPresented: Bool
+    @Environment(\.openWindow) private var openWindow
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isPresented) { show in
+                guard show else { return }
+                openWindow(id: "ArkheionMap")
+                DispatchQueue.main.async { isPresented = false }
             }
-        }
     }
 }
 #else


### PR DESCRIPTION
## Summary
- add a dedicated window scene for `ArkheionMapView`
- present that window using `openWindow` on macOS
- keep iOS behaviour with `fullScreenCover`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6869869fc8ec832f8abb817b82919b11