### PR TITLE
Implement hover/tap radial nav menu

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -88,15 +88,17 @@ struct ArkheionMapView: View {
 
                 controlPanel
 
-                RadialNavMenu(items: [
-                    RadialNavMenuItem(icon: "arrowshape.turn.up.left") {
-                        dismiss()
-                    },
-                    RadialNavMenuItem(icon: "sun.max") {},
-                    RadialNavMenuItem(icon: "shield") {}
-                ])
+                VStack {
+                    RadialNavMenuView(items: [
+                        RadialNavMenuItem(icon: "arrowshape.turn.up.left") {
+                            dismiss()
+                        },
+                        RadialNavMenuItem(icon: "sun.max") {},
+                        RadialNavMenuItem(icon: "shield") {}
+                    ])
+                }
                 .frame(maxWidth: .infinity, alignment: .top)
-                .padding(.top, 10)
+                .padding(.top, 20)
 
                 SidebarControls(
                     zoomIn: { zoom = min(zoom + 0.2, 2.5) },

--- a/Ascension/UIComponents/RadialNavMenuView.swift
+++ b/Ascension/UIComponents/RadialNavMenuView.swift
@@ -6,24 +6,38 @@ struct RadialNavMenuItem: Identifiable {
     var action: () -> Void
 }
 
-struct RadialNavMenu: View {
+struct HalfCircle: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.addArc(center: CGPoint(x: rect.midX, y: rect.maxY),
+                    radius: rect.width / 2,
+                    startAngle: .degrees(180),
+                    endAngle: .degrees(0),
+                    clockwise: false)
+        return path
+    }
+}
+
+struct RadialNavMenuView: View {
     var items: [RadialNavMenuItem]
-    @State private var show = false
-    @State private var hovering = false
+
+    @State private var visible = false
 
     var body: some View {
         GeometryReader { geo in
-            let radius: CGFloat = 130
             ZStack {
-                arcBackground(radius: radius + 40)
-                    .opacity(show ? 1 : 0)
-                    .animation(.easeInOut(duration: 0.25), value: show)
+                HalfCircle()
+                    .fill(.ultraThinMaterial)
+                    .frame(width: geo.size.width, height: geo.size.height)
+                    .shadow(radius: 2)
 
                 ForEach(Array(items.enumerated()), id: \.1.id) { index, item in
                     let progress = Double(index) / Double(max(items.count - 1, 1))
                     let angle = Double.pi * (1 - progress)
-                    let x = radius * cos(angle)
-                    let y = radius * sin(angle)
+                    let radius = geo.size.width / 2 * 0.75
+                    let center = CGPoint(x: geo.size.width / 2, y: geo.size.height)
+                    let x = center.x + radius * cos(angle)
+                    let y = center.y + radius * sin(angle)
 
                     Button(action: item.action) {
                         Image(systemName: item.icon)
@@ -35,53 +49,34 @@ struct RadialNavMenu: View {
                             )
                             .foregroundColor(.white)
                     }
-                    .position(x: geo.size.width / 2 + x,
-                              y: topInset + y)
-                    .scaleEffect(show ? 1 : 0.5)
-                    .opacity(show ? 1 : 0)
+                    .position(x: x, y: y)
+                    .scaleEffect(visible ? 1 : 0.5)
+                    .opacity(visible ? 1 : 0)
                     .animation(
-                        .easeOut(duration: 0.4).delay(Double(index) * 0.05),
-                        value: show
+                        .easeOut(duration: 0.3).delay(Double(index) * 0.05),
+                        value: visible
                     )
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
-        .allowsHitTesting(true)
+        .frame(width: 300, height: 150)
+        .opacity(visible ? 1 : 0)
 #if os(macOS)
         .onHover { hovering in
-            self.hovering = hovering
-            withAnimation { show = hovering }
+            withAnimation { visible = hovering }
         }
 #else
         .onTapGesture {
-            withAnimation { show.toggle() }
+            withAnimation { visible.toggle() }
         }
-#endif
-    }
-
-    private func arcBackground(radius: CGFloat) -> some View {
-        Circle()
-            .trim(from: 0, to: 0.5)
-            .rotation(.degrees(180))
-            .fill(.ultraThinMaterial)
-            .frame(width: radius * 2, height: radius)
-            .offset(y: radius / 2)
-    }
-
-    private var topInset: CGFloat {
-#if os(iOS)
-        return 44
-#else
-        return 20
 #endif
     }
 }
 
 #if DEBUG
-struct RadialNavMenu_Previews: PreviewProvider {
+struct RadialNavMenuView_Previews: PreviewProvider {
     static var previews: some View {
-        RadialNavMenu(items: [
+        RadialNavMenuView(items: [
             RadialNavMenuItem(icon: "arrowshape.turn.up.left", action: {}),
             RadialNavMenuItem(icon: "sun.max", action: {}),
             RadialNavMenuItem(icon: "shield", action: {})


### PR DESCRIPTION
## Summary
- redesign radial menu with a reusable `RadialNavMenuView`
- include a `HalfCircle` background shape and smooth show/hide animation
- integrate new menu into `ArkheionMapView`

## Testing
- `swift -version`

------
https://chatgpt.com/codex/tasks/task_e_6869a5992a60832f866dd23705422d19