### PR TITLE
Enable map dragging by default

### DIFF
--- a/Ascension/Modules/Arkheion/Components/SidebarControls.swift
+++ b/Ascension/Modules/Arkheion/Components/SidebarControls.swift
@@ -3,14 +3,11 @@ import SwiftUI
 struct SidebarControls: View {
     var zoomIn: () -> Void
     var zoomOut: () -> Void
-    var dragMode: Bool
-    var toggleDragMode: () -> Void
 
     var body: some View {
         VStack(spacing: 12) {
             controlButton(icon: "plus", action: zoomIn)
             controlButton(icon: "minus", action: zoomOut)
-            controlButton(icon: "hand.draw", action: toggleDragMode, active: dragMode)
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
@@ -36,7 +33,7 @@ struct SidebarControls: View {
 #if DEBUG
 struct SidebarControls_Previews: PreviewProvider {
     static var previews: some View {
-        SidebarControls(zoomIn: {}, zoomOut: {}, dragMode: true, toggleDragMode: {})
+        SidebarControls(zoomIn: {}, zoomOut: {})
     }
 }
 #endif

--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -27,7 +27,6 @@ struct ArkheionMapView: View {
     @State private var newlyAddedIDs: Set<UUID> = []
 
     // Map navigation state
-    @State private var dragModeActive = false
     @State private var canvasOffset: CGSize = .zero
     @GestureState private var dragTranslation: CGSize = .zero
     @State private var zoom: CGFloat = 1.0
@@ -80,11 +79,7 @@ struct ArkheionMapView: View {
                     x: canvasOffset.width + dragTranslation.width,
                     y: canvasOffset.height + dragTranslation.height
                 )
-#if os(macOS)
                 .gesture(drag)
-#else
-                .gesture(dragModeActive ? drag : nil)
-#endif
 
                 controlPanel
 
@@ -102,9 +97,7 @@ struct ArkheionMapView: View {
 
                 SidebarControls(
                     zoomIn: { zoom = min(zoom + 0.2, 2.5) },
-                    zoomOut: { zoom = max(zoom - 0.2, 0.6) },
-                    dragMode: dragModeActive,
-                    toggleDragMode: { dragModeActive.toggle() }
+                    zoomOut: { zoom = max(zoom - 0.2, 0.6) }
                 )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- remove drag toggle from sidebar controls
- always enable drag gestures on the Arkheion map

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6869a71bef08832fbf9af5a6d5d060c8