### PR TITLE
Extend infinite grid with zoom

### DIFF
--- a/Ascension/Modules/Arkheion/Core/GridOverlayView.swift
+++ b/Ascension/Modules/Arkheion/Core/GridOverlayView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Draws radial and concentric grid lines that adjust spacing based on zoom.
+struct GridOverlayView: View {
+    /// Current zoom factor of the map.
+    var zoom: CGFloat
+
+    private let baseSpacing: CGFloat = 80
+    private let segmentCount = 12
+
+    var body: some View {
+        GeometryReader { _ in
+            Canvas { context, size in
+                let center = CGPoint(x: size.width / 2, y: size.height / 2)
+                let maxRadius = hypot(size.width, size.height) / 2
+
+                // Determine spacing between rings so it appears constant
+                var radius: CGFloat = baseSpacing * zoom
+                while radius <= maxRadius {
+                    var path = Path()
+                    path.addEllipse(in: CGRect(x: center.x - radius,
+                                               y: center.y - radius,
+                                               width: radius * 2,
+                                               height: radius * 2))
+                    let alpha = 0.2 * (1.0 - (radius / maxRadius))
+                    context.stroke(path, with: .color(Color.white.opacity(alpha)), lineWidth: 0.5)
+                    radius += baseSpacing * zoom
+                }
+
+                // Radial segments
+                for i in 0..<segmentCount {
+                    let angle = Double(i) / Double(segmentCount) * 2 * .pi
+                    var path = Path()
+                    path.move(to: center)
+                    path.addLine(to: CGPoint(x: center.x + cos(angle) * maxRadius,
+                                             y: center.y + sin(angle) * maxRadius))
+                    context.stroke(path, with: .color(Color.white.opacity(0.1)), lineWidth: 0.5)
+                }
+            }
+            .drawingGroup()
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    GridOverlayView(zoom: 1)
+        .frame(width: 300, height: 300)
+}
+#endif


### PR DESCRIPTION
## Summary
- move `GridOverlayView` to its own file
- add zoom-based spacing for grid rings so it expands with zoom
- extend `BackgroundLayer` shimmer radius based on zoom
- restructure `ArkheionMapView` to supply zoom to background and grid

## Testing
- `swift test --enable-test-discovery` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686d4e0fd64c832fb7c9022955bde7f3