### PR TITLE
Fix grid scaling and background overlay

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -27,31 +27,33 @@ struct ArkheionMapView: View {
             let currentZoom = zoom * gestureZoom
 
             ZStack {
-                BackgroundLayer(zoom: currentZoom)
-
-                if showGrid {
-                    GridOverlayView(zoom: currentZoom)
-                        .blendMode(.overlay)
-                }
+                BackgroundLayer()
 
                 ZStack {
-                    CoreGlowView()
-                        .frame(width: 140, height: 140)
-                        .position(center)
-
-                    ForEach(rings) { ring in
-                        RingView(ring: ring, center: center) { index in
-                            onRingTapped(ringIndex: index)
-                        }
+                    if showGrid {
+                        GridOverlayView()
+                            .blendMode(.overlay)
                     }
 
-                    // Placeholder: branches and node layers will follow
+                    ZStack {
+                        CoreGlowView()
+                            .frame(width: 140, height: 140)
+                            .position(center)
+
+                        ForEach(rings) { ring in
+                            RingView(ring: ring, center: center) { index in
+                                onRingTapped(ringIndex: index)
+                            }
+                        }
+
+                        // Placeholder: branches and node layers will follow
+                    }
                 }
                 .scaleEffect(currentZoom)
                 .offset(x: offset.width + dragTranslation.width,
                         y: offset.height + dragTranslation.height)
-                .gesture(dragGesture.simultaneously(with: zoomGesture))
             }
+            .gesture(dragGesture.simultaneously(with: zoomGesture))
             .frame(width: geo.size.width, height: geo.size.height)
             .ignoresSafeArea()
             .overlay(gridToggleButton, alignment: .topTrailing)
@@ -107,8 +109,6 @@ struct ArkheionMapView: View {
 
 /// Provides the multi-gradient backdrop with a subtle shimmer.
 struct BackgroundLayer: View {
-    /// Zoom factor determines how spread out the shimmer effect appears.
-    var zoom: CGFloat
 
     var body: some View {
         GeometryReader { geo in
@@ -129,7 +129,7 @@ struct BackgroundLayer: View {
                     gradient: Gradient(colors: [Color.white.opacity(0.15), .clear]),
                     center: .center,
                     startRadius: 0,
-                    endRadius: max(geo.size.width, geo.size.height) * zoom
+                    endRadius: max(geo.size.width, geo.size.height)
                 )
                 .blendMode(.screen)
             }

--- a/Ascension/Modules/Arkheion/Core/GridOverlayView.swift
+++ b/Ascension/Modules/Arkheion/Core/GridOverlayView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 
-/// Draws radial and concentric grid lines that adjust spacing based on zoom.
+/// Draws radial and concentric grid lines that move with the map content.
 struct GridOverlayView: View {
-    /// Current zoom factor of the map.
-    var zoom: CGFloat
 
     private let baseSpacing: CGFloat = 80
     private let segmentCount = 12
@@ -12,10 +10,10 @@ struct GridOverlayView: View {
         GeometryReader { _ in
             Canvas { context, size in
                 let center = CGPoint(x: size.width / 2, y: size.height / 2)
-                let maxRadius = hypot(size.width, size.height) / 2
+                let maxRadius = hypot(size.width, size.height) * 2
 
                 // Determine spacing between rings so it appears constant
-                var radius: CGFloat = baseSpacing * zoom
+                var radius: CGFloat = baseSpacing
                 while radius <= maxRadius {
                     var path = Path()
                     path.addEllipse(in: CGRect(x: center.x - radius,
@@ -24,7 +22,7 @@ struct GridOverlayView: View {
                                                height: radius * 2))
                     let alpha = 0.2 * (1.0 - (radius / maxRadius))
                     context.stroke(path, with: .color(Color.white.opacity(alpha)), lineWidth: 0.5)
-                    radius += baseSpacing * zoom
+                    radius += baseSpacing
                 }
 
                 // Radial segments
@@ -44,7 +42,7 @@ struct GridOverlayView: View {
 
 #if DEBUG
 #Preview {
-    GridOverlayView(zoom: 1)
+    GridOverlayView()
         .frame(width: 300, height: 300)
 }
 #endif


### PR DESCRIPTION
## Summary
- keep grid spacing constant and extend grid size
- scale grid with the map and offset both together
- remove zoom-based background adjustments

## Testing
- `swift test --enable-code-coverage` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686d4fb95c50832fb0c8ea045a5423cc