### PR TITLE
Wrap ring index for sheet presentation

### DIFF
--- a/Ascension/Int+Identifiable.swift
+++ b/Ascension/Int+Identifiable.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-extension Int: Identifiable {
-    public var id: Int { self }
-}

--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -13,7 +13,8 @@ struct ArkheionMapView: View {
     ]
 
     @State private var branches: [Branch] = []
-    @State private var editingRingIndex: Int?
+    /// Holds the ring currently being edited.
+    @State private var editingRing: RingEditTarget?
 
     // MARK: - Gestures
     @State private var zoom: CGFloat = 1.0
@@ -49,7 +50,7 @@ struct ArkheionMapView: View {
                                 center: center,
                                 onTap: { index in onRingTapped(ringIndex: index) },
                                 onLongPress: { index in toggleLock(for: index) },
-                                onDoubleTap: { index in editingRingIndex = index }
+                                onDoubleTap: { index in editingRing = RingEditTarget(ringIndex: index) }
                             )
                         }
 
@@ -71,8 +72,8 @@ struct ArkheionMapView: View {
             .ignoresSafeArea()
             .overlay(gridToggleButton, alignment: .topTrailing)
             .overlay(addRingButton, alignment: .bottomTrailing)
-            .sheet(item: $editingRingIndex) { index in
-                if let i = index, let binding = bindingForRing(i) {
+            .sheet(item: $editingRing) { target in
+                if let binding = bindingForRing(target.ringIndex) {
                     RingEditorView(ring: binding)
                 }
             }

--- a/Ascension/Modules/Arkheion/Core/RingEditTarget.swift
+++ b/Ascension/Modules/Arkheion/Core/RingEditTarget.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Wrapper used when presenting the ring editor via `sheet(item:)`.
+/// Stores the ring index and conforms to `Identifiable`.
+struct RingEditTarget: Identifiable {
+    var ringIndex: Int
+    var id: Int { ringIndex }
+}


### PR DESCRIPTION
## Summary
- stop extending `Int` with `Identifiable`
- wrap the ring index in a new `RingEditTarget` struct
- refactor `ArkheionMapView` to use `RingEditTarget` with `.sheet(item:)`

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*
- `xcodebuild -list` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d61948004832f80e95469b7e2dd88