### PR TITLE
Add floating ring editor panel

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -72,9 +72,15 @@ struct ArkheionMapView: View {
             .ignoresSafeArea()
             .overlay(gridToggleButton, alignment: .topTrailing)
             .overlay(addRingButton, alignment: .bottomTrailing)
-            .sheet(item: $editingRing) { target in
-                if let binding = bindingForRing(target.ringIndex) {
-                    RingEditorView(ring: binding)
+            .overlay(alignment: .top) {
+                if let target = editingRing,
+                   let binding = bindingForRing(target.ringIndex) {
+                    FloatingRingEditorView(
+                        ring: binding,
+                        progress: progress(for: target.ringIndex),
+                        onBack: { editingRing = nil }
+                    )
+                    .padding(.top, 20)
                 }
             }
         }
@@ -158,6 +164,15 @@ struct ArkheionMapView: View {
     private func addNode(to branchID: UUID) {
         guard let index = branches.firstIndex(where: { $0.id == branchID }) else { return }
         branches[index].nodes.append(Node())
+    }
+
+    /// Calculates completion progress for a ring based on nodes finished.
+    private func progress(for ringIndex: Int) -> Double {
+        let ringBranches = branches.filter { $0.ringIndex == ringIndex }
+        let nodes = ringBranches.flatMap { $0.nodes }
+        guard !nodes.isEmpty else { return 0 }
+        let completed = nodes.filter { $0.completed }.count
+        return Double(completed) / Double(nodes.count)
     }
 }
 

--- a/Ascension/Modules/Arkheion/Editor/FloatingRingEditorView.swift
+++ b/Ascension/Modules/Arkheion/Editor/FloatingRingEditorView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// Floating panel for editing a ring. Can be dragged around the screen.
+struct FloatingRingEditorView: View {
+    @Binding var ring: Ring
+    var progress: Double
+    var onBack: () -> Void
+
+    @State private var offset: CGSize = .zero
+    @GestureState private var dragState: CGSize = .zero
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left")
+                        .padding(4)
+                }
+                Spacer()
+            }
+
+            Button(action: { ring.locked.toggle() }) {
+                Label(ring.locked ? "Locked" : "Unlocked",
+                      systemImage: ring.locked ? "lock.fill" : "lock.open")
+                    .foregroundColor(ring.locked ? .gray : .green)
+            }
+            .buttonStyle(.bordered)
+
+            HStack {
+                Text("Radius")
+                Slider(value: $ring.radius, in: 100...600)
+            }
+
+            ProgressView(value: progress) {
+                Text("Progress")
+            }
+            .progressViewStyle(.linear)
+        }
+        .padding()
+        .background(.ultraThinMaterial)
+        .cornerRadius(12)
+        .offset(x: offset.width + dragState.width,
+                y: offset.height + dragState.height)
+        .gesture(
+            DragGesture()
+                .updating($dragState) { value, state, _ in
+                    state = value.translation
+                }
+                .onEnded { value in
+                    offset.width += value.translation.width
+                    offset.height += value.translation.height
+                }
+        )
+        .frame(maxWidth: 300)
+    }
+}
+
+#if DEBUG
+struct FloatingRingEditorView_Previews: PreviewProvider {
+    static var previews: some View {
+        FloatingRingEditorView(
+            ring: .constant(Ring(ringIndex: 0, radius: 200, locked: false)),
+            progress: 0.5,
+            onBack: {}
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- implement `FloatingRingEditorView` for a movable editor panel
- show the panel from `ArkheionMapView` instead of using a sheet
- compute ring completion progress

## Testing
- `swiftc --version`
- `swift test --disable-sandbox` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e6addd0832f8985b3012f7329ba