### PR TITLE
Improve hit testing for Arkheion map

### DIFF
--- a/Ascension/Modules/Arkheion/Core/RingView.swift
+++ b/Ascension/Modules/Arkheion/Core/RingView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 /// Data model representing a single concentric ring in the Arkheion map.
 struct Ring: Identifiable {
@@ -15,26 +18,50 @@ struct RingView: View {
     var onTap: (Int) -> Void = { _ in }
     var onLongPress: (Int) -> Void = { _ in }
     var onDoubleTap: (Int) -> Void = { _ in }
+    @State private var isHighlighted = false
 
     private var strokeColor: Color {
         ring.locked ? Color.white.opacity(0.2) : Color.white.opacity(0.4)
     }
 
     var body: some View {
-        Circle()
-            .stroke(strokeColor, lineWidth: 2)
-            .frame(width: ring.radius * 2, height: ring.radius * 2)
-            .position(x: center.x, y: center.y)
-            .shadow(color: ring.locked ? .clear : Color.white.opacity(0.5), radius: ring.locked ? 0 : 4)
-            .onTapGesture(count: 2) {
-                onDoubleTap(ring.ringIndex)
-            }
-            .onTapGesture {
-                onTap(ring.ringIndex)
-            }
-            .onLongPressGesture {
-                onLongPress(ring.ringIndex)
-            }
+        ZStack {
+            Circle()
+                .stroke(Color.white.opacity(0.6), lineWidth: 4)
+                .frame(width: ring.radius * 2 + 8, height: ring.radius * 2 + 8)
+                .opacity(isHighlighted ? 1 : 0)
+                .animation(.easeOut(duration: 0.4), value: isHighlighted)
+
+            Circle()
+                .stroke(strokeColor, lineWidth: 2)
+                .frame(width: ring.radius * 2, height: ring.radius * 2)
+        }
+        .padding(20)
+        .contentShape(Circle().inset(by: -20))
+        .position(x: center.x, y: center.y)
+        .shadow(color: ring.locked ? .clear : Color.white.opacity(0.5), radius: ring.locked ? 0 : 4)
+        .onTapGesture(count: 2) {
+            highlight();
+            onDoubleTap(ring.ringIndex)
+        }
+        .onTapGesture {
+            highlight();
+            onTap(ring.ringIndex)
+        }
+        .onLongPressGesture {
+            highlight();
+            onLongPress(ring.ringIndex)
+        }
+    }
+
+    private func highlight() {
+#if os(iOS)
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+#endif
+        isHighlighted = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            isHighlighted = false
+        }
     }
 }
 

--- a/Ascension/Modules/Arkheion/Editor/BranchView.swift
+++ b/Ascension/Modules/Arkheion/Editor/BranchView.swift
@@ -32,6 +32,10 @@ struct BranchView: View {
                 Circle()
                     .fill(node.attribute.color)
                     .frame(width: node.size.radius * 2, height: node.size.radius * 2)
+                    .padding(12)
+                    .contentShape(Circle().inset(by: -12))
+                    .scaleEffect(selectedNode?.id == node.id ? 1.2 : 1.0)
+                    .animation(.easeInOut(duration: 0.2), value: selectedNode?.id == node.id)
                     .position(position)
                     .shadow(color: node.completed ? .clear : node.attribute.color, radius: node.completed ? 0 : 6)
                     .onTapGesture { selectedNode = branch.nodes[index] }
@@ -40,6 +44,8 @@ struct BranchView: View {
             Circle()
                 .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [4]))
                 .frame(width: 24, height: 24)
+                .padding(10)
+                .contentShape(Circle().inset(by: -10))
                 .position(x: center.x + cos(branch.angle) * ringRadius,
                           y: center.y + sin(branch.angle) * ringRadius)
                 .onTapGesture { onAddNode() }


### PR DESCRIPTION
## Summary
- enlarge hit area on nodes and add highlight animation when selected
- enlarge hit area on the node creation circle
- enlarge ring hit testing region, add haptic/highlight feedback

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686d7aebf078832fa317b484ad978c23