### PR TITLE
Improve branch tap hit detection

### DIFF
--- a/Ascension/Modules/Arkheion/Editor/BranchView.swift
+++ b/Ascension/Modules/Arkheion/Editor/BranchView.swift
@@ -75,6 +75,8 @@ struct BranchView: View {
                           y: center.y + sin(branch.angle) * ringRadius)
                 .onTapGesture { onAddNode() }
         }
+        .contentShape(Rectangle())
+        .zIndex(1)
     }
 }
 


### PR DESCRIPTION
## Summary
- draw branches above rings and expand branch hit area
- detect branch taps before ring taps to avoid interference

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686da7656c30832f95e6b6b3dbfabe7c