### PR TITLE
Fix branch hit testing around ring

### DIFF
--- a/Ascension/Modules/Arkheion/Editor/BranchView.swift
+++ b/Ascension/Modules/Arkheion/Editor/BranchView.swift
@@ -31,13 +31,12 @@ struct BranchView: View {
         ZStack {
             branchPath
                 .stroke(selectedBranchID == branch.id ? Color.white : Color.white.opacity(0.5), lineWidth: selectedBranchID == branch.id ? 4 : 2)
-                .background(branchPath.stroke(Color.clear, lineWidth: 20))
-                .contentShape(Rectangle())
+                .contentShape(branchPath.strokedPath(StrokeStyle(lineWidth: 20)))
                 .onTapGesture {
                     selectedBranchID = branch.id
                     selectedNodeID = nil
                 }
-                .zIndex(10)
+                .zIndex(2)
 
             ForEach(Array(branch.nodes.enumerated()), id: \.1.id) { index, node in
                 let distance = ringRadius + CGFloat(index + 1) * 60
@@ -74,7 +73,7 @@ struct BranchView: View {
                           y: center.y + sin(branch.angle) * ringRadius)
                 .onTapGesture { onAddNode() }
         }
-        .contentShape(Rectangle())
+        .contentShape(branchPath)
         .zIndex(1)
     }
 }


### PR DESCRIPTION
## Summary
- tighten hit testing for branch selection
- balance z-index so branches don't block rings

## Testing
- `swift -version`

------
https://chatgpt.com/codex/tasks/task_e_686ec8568bf4832f8b400159f379ae3f