### PR TITLE
Add branch/node deletion and reordering

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -123,7 +123,11 @@ struct ArkheionMapView: View {
                     unlockAllRings: unlockAllRings,
                     deleteRing: deleteSelectedRing,
                     createBranch: createBranch,
-                    addNode: addNodeFromToolbar
+                    addNode: addNodeFromToolbar,
+                    deleteBranch: deleteSelectedBranch,
+                    deleteNode: deleteSelectedNode,
+                    moveNodeUp: moveSelectedNodeUp,
+                    moveNodeDown: moveSelectedNodeDown
                 )
                 .padding(.trailing, 8)
             }
@@ -222,7 +226,9 @@ struct ArkheionMapView: View {
 
     private func addNode(to branchID: UUID) {
         guard let index = branches.firstIndex(where: { $0.id == branchID }) else { return }
-        branches[index].nodes.append(Node())
+        let node = Node()
+        branches[index].nodes.insert(node, at: 0)
+        selectedNodeID = node.id
     }
 
     private func unlockAllRings() {
@@ -242,6 +248,34 @@ struct ArkheionMapView: View {
     private func addNodeFromToolbar() {
         guard let branchID = selectedBranchID else { return }
         addNode(to: branchID)
+    }
+
+    private func deleteSelectedBranch() {
+        guard let id = selectedBranchID else { return }
+        branches.removeAll { $0.id == id }
+        selectedBranchID = nil
+        selectedNodeID = nil
+    }
+
+    private func deleteSelectedNode() {
+        guard let branchID = selectedBranchID, let nodeID = selectedNodeID else { return }
+        guard let bIndex = branches.firstIndex(where: { $0.id == branchID }) else { return }
+        branches[bIndex].nodes.removeAll { $0.id == nodeID }
+        selectedNodeID = nil
+    }
+
+    private func moveSelectedNodeUp() {
+        guard let branchID = selectedBranchID, let nodeID = selectedNodeID else { return }
+        guard let bIndex = branches.firstIndex(where: { $0.id == branchID }) else { return }
+        guard let nIndex = branches[bIndex].nodes.firstIndex(where: { $0.id == nodeID }), nIndex > 0 else { return }
+        branches[bIndex].nodes.swapAt(nIndex, nIndex - 1)
+    }
+
+    private func moveSelectedNodeDown() {
+        guard let branchID = selectedBranchID, let nodeID = selectedNodeID else { return }
+        guard let bIndex = branches.firstIndex(where: { $0.id == branchID }) else { return }
+        guard let nIndex = branches[bIndex].nodes.firstIndex(where: { $0.id == nodeID }), nIndex < branches[bIndex].nodes.count - 1 else { return }
+        branches[bIndex].nodes.swapAt(nIndex, nIndex + 1)
     }
 
     /// Calculates completion progress for a ring based on nodes finished.

--- a/Ascension/Modules/Arkheion/Editor/EditorToolbarView.swift
+++ b/Ascension/Modules/Arkheion/Editor/EditorToolbarView.swift
@@ -21,6 +21,10 @@ struct EditorToolbarView: View {
     var deleteRing: () -> Void = {}
     var createBranch: () -> Void = {}
     var addNode: () -> Void = {}
+    var deleteBranch: () -> Void = {}
+    var deleteNode: () -> Void = {}
+    var moveNodeUp: () -> Void = {}
+    var moveNodeDown: () -> Void = {}
 
     var body: some View {
         HStack(spacing: 0) {
@@ -92,6 +96,11 @@ struct EditorToolbarView: View {
             Button(action: createBranch) {
                 Label("Create New Branch", systemImage: "line.diagonal.arrow")
             }
+            if selectedBranchID != nil {
+                Button(role: .destructive, action: deleteBranch) {
+                    Label("Delete Branch", systemImage: "trash")
+                }
+            }
             Picker("Ring", selection: $selectedRingIndex) {
                 Text("None").tag(Int?.none)
                 ForEach(rings) { ring in
@@ -118,6 +127,19 @@ struct EditorToolbarView: View {
                 Label("Add Node", systemImage: "plus")
             }
             .disabled(selectedBranchID == nil)
+            if selectedNodeID != nil {
+                HStack {
+                    Button(action: moveNodeUp) {
+                        Image(systemName: "arrow.up")
+                    }
+                    Button(action: moveNodeDown) {
+                        Image(systemName: "arrow.down")
+                    }
+                }
+                Button(role: .destructive, action: deleteNode) {
+                    Label("Delete Node", systemImage: "trash")
+                }
+            }
             if let nodeBinding = bindingForNode(selectedNodeID, branchID: selectedBranchID) {
                 Picker("Type", selection: nodeBinding.type) {
                     ForEach(NodeType.allCases) { type in


### PR DESCRIPTION
## Summary
- enable deletion of branches and nodes
- allow reordering of nodes within a branch
- insert new nodes at the beginning of a branch
- expose new controls for branch and node actions in the editor toolbar

## Testing
- `swift test -t` *(fails: Unknown option)*

------
https://chatgpt.com/codex/tasks/task_e_686edcd4109c832fb464671942881aac