### PR TITLE
Fix node hit testing near ring top

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -396,7 +396,7 @@ struct ArkheionMapView: View {
                     x: center.x + cos(branch.angle) * distance,
                     y: center.y + sin(branch.angle) * distance
                 )
-                let hitRadius = node.size.radius + 12
+                let hitRadius = node.size.radius + NodeView.hitPadding
                 if hypot(point.x - position.x, point.y - position.y) <= hitRadius {
                     return (branch.id, node.id)
                 }

--- a/Ascension/Modules/Arkheion/Editor/BranchView.swift
+++ b/Ascension/Modules/Arkheion/Editor/BranchView.swift
@@ -41,19 +41,8 @@ struct BranchView: View {
                     y: center.y + sin(branch.angle) * distance
                 )
 
-                Circle()
-                    .fill(node.attribute.color)
-                    .frame(width: node.size.radius * 2, height: node.size.radius * 2)
-                    .padding(12)
-                    .contentShape(Circle().inset(by: -12))
-                    .overlay(
-                        Circle()
-                            .stroke(Color.white, lineWidth: selectedNodeID == node.id ? 3 : 0)
-                    )
-                    .scaleEffect(selectedNodeID == node.id ? 1.2 : 1.0)
-                    .animation(.easeInOut(duration: 0.2), value: selectedNodeID == node.id)
+                NodeView(node: node, selected: selectedNodeID == node.id)
                     .position(position)
-                    .shadow(color: node.completed ? .clear : node.attribute.color, radius: node.completed ? 0 : 6)
             }
 
             Circle()

--- a/Ascension/Modules/Arkheion/Editor/NodeView.swift
+++ b/Ascension/Modules/Arkheion/Editor/NodeView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Visual representation of a single node with an enlarged hit area.
+struct NodeView: View {
+    var node: Node
+    var selected: Bool
+
+    /// Padding applied around the node for hit testing.
+    static let hitPadding: CGFloat = 20
+
+    var body: some View {
+        Circle()
+            .fill(node.attribute.color)
+            .frame(width: node.size.radius * 2, height: node.size.radius * 2)
+            .padding(Self.hitPadding)
+            .contentShape(Circle().inset(by: -Self.hitPadding))
+            .overlay(
+                Circle()
+                    .stroke(Color.white, lineWidth: selected ? 3 : 0)
+            )
+            .scaleEffect(selected ? 1.2 : 1.0)
+            .animation(.easeInOut(duration: 0.2), value: selected)
+            .shadow(color: node.completed ? .clear : node.attribute.color,
+                    radius: node.completed ? 0 : 6)
+    }
+}
+
+#if DEBUG
+#Preview {
+    NodeView(node: Node(), selected: true)
+}
+#endif


### PR DESCRIPTION
## Summary
- add `NodeView` with larger `contentShape`
- render nodes using `NodeView`
- use `NodeView.hitPadding` for node hit tests

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870049092f8832fa503333bbeb40d7b