### PR TITLE
Fix Tap Selection Interactivity

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -100,6 +100,16 @@ struct ArkheionMapView: View {
                 // Expanded invisible layer capturing taps and hovers well
                 // beyond the visible frame.
                 interactionLayer(center: center, geo: geo)
+
+                TapCaptureView(
+                    onTap: { handleTap(at: convert(location: $0, in: geo), in: geo) },
+                    onDoubleTap: { handleDoubleTap(at: convert(location: $0, in: geo), in: geo) },
+                    onLongPress: { handleLongPress(at: convert(location: $0, in: geo), in: geo) }
+                )
+                .frame(width: geo.size.width * interactionScale,
+                       height: geo.size.height * interactionScale)
+                .position(center)
+                .zIndex(999)
                 
             }
             .gesture(dragGesture.simultaneously(with: zoomGesture))
@@ -156,8 +166,6 @@ struct ArkheionMapView: View {
                    height: geo.size.height * interactionScale)
             .position(center)
             .contentShape(Rectangle())
-            .gesture(interactionGesture(in: geo))
-            .simultaneousGesture(doubleTapGesture(in: geo))
     }
 
     // MARK: - Gestures
@@ -418,6 +426,7 @@ struct ArkheionMapView: View {
         let angle = atan2(point.y - center.y, point.x - center.x)
         guard let ring = store.rings.min(by: { abs(distance - $0.radius) < abs(distance - $1.radius) }) else { return nil }
         if abs(distance - ring.radius) <= 20 {
+            print("[ArkheionMap] ringHit -> index=\(ring.ringIndex) angle=\(angle)")
             return (ring.ringIndex, Double(angle))
         }
 
@@ -452,6 +461,7 @@ struct ArkheionMapView: View {
                 )
                 let hitRadius = node.size.radius + NodeView.hitPadding
                 if hypot(point.x - position.x, point.y - position.y) <= hitRadius {
+                    print("[ArkheionMap] hitNode -> branch=\(branch.id) node=\(node.id)")
                     return (branch.id, node.id)
                 }
             }
@@ -493,6 +503,7 @@ struct ArkheionMapView: View {
                 y: origin.y + sin(branch.angle) * length
             )
             if distance(from: point, toSegment: origin, end: end) <= 20 {
+                print("[ArkheionMap] hitBranch -> id=\(branch.id)")
                 return branch.id
             }
         }

--- a/Ascension/Modules/Arkheion/Core/RingView.swift
+++ b/Ascension/Modules/Arkheion/Core/RingView.swift
@@ -36,6 +36,8 @@ struct RingView: View {
         .padding(20)
         .position(x: center.x, y: center.y)
         .shadow(color: ring.locked ? .clear : Color.white.opacity(0.5), radius: ring.locked ? 0 : 4)
+        .contentShape(Rectangle())
+        .allowsHitTesting(true)
     }
 }
 

--- a/Ascension/Modules/Arkheion/Editor/BranchView.swift
+++ b/Ascension/Modules/Arkheion/Editor/BranchView.swift
@@ -75,7 +75,8 @@ struct BranchView: View {
                     hoveringBase = hovering
                 }
         }
-        .contentShape(branchPath)
+        .contentShape(Rectangle())
+        .allowsHitTesting(true)
         .zIndex(1)
     }
 }

--- a/Ascension/Modules/Arkheion/Editor/NodeView.swift
+++ b/Ascension/Modules/Arkheion/Editor/NodeView.swift
@@ -21,7 +21,7 @@ struct NodeView: View {
         base
             .frame(width: node.size.radius * 2, height: node.size.radius * 2)
             .padding(Self.hitPadding)
-            .contentShape(Circle().inset(by: -Self.hitPadding))
+            .contentShape(Rectangle())
             .overlay(
                 Circle()
                     .stroke(Color.white, lineWidth: selected ? 3 : 0)
@@ -30,6 +30,7 @@ struct NodeView: View {
             .animation(.easeInOut(duration: 0.2), value: selected)
             .shadow(color: node.completed ? .clear : node.attribute.color,
                     radius: node.completed ? 0 : 6)
+            .allowsHitTesting(true)
     }
 }
 


### PR DESCRIPTION
## Summary
- reintroduce `TapCaptureView` to handle taps
- remove drag recognizer from `interactionLayer`
- ensure RingView, BranchView and NodeView participate in hit testing
- log hit detection for easier debugging

## Testing
- `xcodebuild -list -project Ascension.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68706a26c790832fb214c3a8e9f6fde9