### PR TITLE
Fix add node crash and guard toolbar

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -322,7 +322,13 @@ struct ArkheionMapView: View {
     }
 
     private func addNode(to branchID: UUID) {
-        guard let index = store.branches.firstIndex(where: { $0.id == branchID }) else { return }
+        let branchIDs = store.branches.map { $0.id }
+        print("[ArkheionMap] addNode -> selectedBranchID=\(String(describing: selectedBranchID))")
+        print("[ArkheionMap] Current branches: \(branchIDs)")
+        guard let index = store.branches.firstIndex(where: { $0.id == branchID }) else {
+            print("[ArkheionMap] addNode aborted: branch \(branchID) not found")
+            return
+        }
         let node = Node()
         store.branches[index].nodes.insert(node, at: 0)
         selectedNodeID = node.id
@@ -354,7 +360,15 @@ struct ArkheionMapView: View {
     }
 
     private func addNodeFromToolbar() {
-        guard let branchID = selectedBranchID else { return }
+        guard let branchID = selectedBranchID else {
+            print("[ArkheionMap] addNodeFromToolbar called with no branch selected")
+            return
+        }
+        guard store.branches.contains(where: { $0.id == branchID }) else {
+            print("[ArkheionMap] addNodeFromToolbar aborted: selected branch \(branchID) missing")
+            selectedBranchID = nil
+            return
+        }
         addNode(to: branchID)
     }
 

--- a/Ascension/Modules/Arkheion/Editor/EditorToolbarView.swift
+++ b/Ascension/Modules/Arkheion/Editor/EditorToolbarView.swift
@@ -124,10 +124,13 @@ struct EditorToolbarView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Node Controls")
                 .font(.headline)
+            let validBranchSelected = selectedBranchID.flatMap { id in
+                branches.contains(where: { $0.id == id })
+            } ?? false
             Button(action: addNode) {
                 Label("Add Node", systemImage: "plus")
             }
-            .disabled(selectedBranchID == nil)
+            .disabled(!validBranchSelected)
             if selectedNodeID != nil {
                 HStack {
                     Button(action: moveNodeUp) {


### PR DESCRIPTION
## Summary
- add logging and checks to `addNode(to:)`
- validate branch selection in `addNodeFromToolbar`
- disable toolbar Add Node button when the branch is missing

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872bbdbd460832f8d39feb2b085318f