### PR TITLE
Add custom macOS cursor overlay

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 /// Main view presenting the Arkheion map. This rewrite focuses on the base
 /// space layer while keeping compatibility with existing data models. Future
@@ -29,6 +32,11 @@ struct ArkheionMapView: View {
     // Hover indicator
     @State private var hoverRingIndex: Int? = nil
     @State private var hoverAngle: Double = 0.0
+
+#if os(macOS)
+    @State private var cursorPoint: CGPoint = .zero
+    @State private var cursorHovering = false
+#endif
 
     /// Scale factor used to expand the invisible hit area around the map.
     private let interactionScale: CGFloat = 4
@@ -121,6 +129,18 @@ struct ArkheionMapView: View {
             .onHover { hovering in
                 if !hovering { hoverRingIndex = nil }
             }
+#if os(macOS)
+            .onChange(of: cursorHovering) { inside in
+                if inside {
+                    NSCursor.hide()
+                } else {
+                    NSCursor.unhide()
+                }
+            }
+            .onDisappear {
+                NSCursor.unhide()
+            }
+#endif
             .overlay(gridToggleButton, alignment: .topTrailing)
             .overlay(addRingButton, alignment: .bottomTrailing)
             .overlay(alignment: .top) {
@@ -153,6 +173,16 @@ struct ArkheionMapView: View {
                 )
                 .padding(.trailing, 8)
             }
+#if os(macOS)
+            .overlay(
+                CursorTrackerView(location: $cursorPoint, hovering: $cursorHovering)
+                    .allowsHitTesting(false)
+            )
+            .overlay(
+                CustomCursorView(location: cursorPoint, visible: cursorHovering)
+                    .allowsHitTesting(false)
+            )
+#endif
         }
     }
 

--- a/Ascension/Modules/Arkheion/Core/CursorTrackerView.swift
+++ b/Ascension/Modules/Arkheion/Core/CursorTrackerView.swift
@@ -1,0 +1,77 @@
+#if os(macOS)
+import SwiftUI
+import AppKit
+
+/// View that tracks the mouse location and hover state within its bounds
+/// without interfering with hit testing. Used to drive the custom cursor
+/// overlay.
+struct CursorTrackerView: NSViewRepresentable {
+    @Binding var location: CGPoint
+    @Binding var hovering: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(location: $location, hovering: $hovering)
+    }
+
+    func makeNSView(context: Context) -> TrackingView {
+        let view = TrackingView()
+        view.coordinator = context.coordinator
+        return view
+    }
+
+    func updateNSView(_ nsView: TrackingView, context: Context) {}
+
+    // MARK: - Coordinator
+    class Coordinator {
+        var location: Binding<CGPoint>
+        var hovering: Binding<Bool>
+        init(location: Binding<CGPoint>, hovering: Binding<Bool>) {
+            self.location = location
+            self.hovering = hovering
+        }
+
+        func update(location: CGPoint) {
+            self.location.wrappedValue = location
+        }
+
+        func update(hovering: Bool) {
+            self.hovering.wrappedValue = hovering
+        }
+    }
+
+    // MARK: - Tracking View
+    class TrackingView: NSView {
+        weak var coordinator: Coordinator?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            window?.acceptsMouseMovedEvents = true
+        }
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            for area in trackingAreas { removeTrackingArea(area) }
+            let options: NSTrackingArea.Options = [
+                .mouseMoved,
+                .mouseEnteredAndExited,
+                .activeInKeyWindow,
+                .inVisibleRect
+            ]
+            let area = NSTrackingArea(rect: .zero, options: options, owner: self, userInfo: nil)
+            addTrackingArea(area)
+        }
+
+        override func mouseMoved(with event: NSEvent) {
+            coordinator?.update(location: convert(event.locationInWindow, from: nil))
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            coordinator?.update(hovering: true)
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            coordinator?.update(hovering: false)
+        }
+    }
+}
+#endif

--- a/Ascension/Modules/Arkheion/Core/CustomCursorView.swift
+++ b/Ascension/Modules/Arkheion/Core/CustomCursorView.swift
@@ -1,0 +1,20 @@
+#if os(macOS)
+import SwiftUI
+
+/// Simple glowing circle used as the in-app cursor
+struct CustomCursorView: View {
+    var location: CGPoint
+    var visible: Bool
+
+    var body: some View {
+        Circle()
+            .fill(Color.white)
+            .frame(width: 12, height: 12)
+            .shadow(color: Color.white.opacity(0.8), radius: 4)
+            .position(location)
+            .opacity(visible ? 1 : 0)
+            .animation(.linear(duration: 0.05), value: location)
+            .allowsHitTesting(false)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- implement `CursorTrackerView` for mouse location tracking
- implement `CustomCursorView` to render the glowing cursor
- overlay the custom cursor in `ArkheionMapView` and hide the system cursor when hovering

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6874043dca6c832f93b8851fbf82e44e