### PR TITLE
Add drag-to-select and multi-selection

### DIFF
--- a/Ascension/Modules/Arkheion/Core/RingView.swift
+++ b/Ascension/Modules/Arkheion/Core/RingView.swift
@@ -16,6 +16,7 @@ struct RingView: View {
     var ring: Ring
     var center: CGPoint
     var highlighted: Bool = false
+    var selected: Bool = false
 
     private var strokeColor: Color {
         ring.locked ? Color.white.opacity(0.2) : Color.white.opacity(0.4)
@@ -32,6 +33,10 @@ struct RingView: View {
             Circle()
                 .stroke(strokeColor, lineWidth: 2)
                 .frame(width: ring.radius * 2, height: ring.radius * 2)
+                .overlay(
+                    Circle()
+                        .stroke(Color.white, lineWidth: selected ? 3 : 0)
+                )
         }
         .padding(20)
         .position(x: center.x, y: center.y)

--- a/Ascension/Modules/Arkheion/Editor/BranchView.swift
+++ b/Ascension/Modules/Arkheion/Editor/BranchView.swift
@@ -7,6 +7,8 @@ struct BranchView: View {
     var ringRadius: CGFloat
     @Binding var selectedBranchID: UUID?
     @Binding var selectedNodeID: UUID?
+    var multiSelected: Bool = false
+    var selectedNodeIDs: Set<UUID> = []
     var onAddNode: () -> Void = {}
 
     /// When hovering the base of the branch we show the dashed add control
@@ -48,7 +50,10 @@ struct BranchView: View {
 
         ZStack {
             branchPath
-                .stroke(selectedBranchID == branch.id ? Color.white : Color.white.opacity(0.5), lineWidth: selectedBranchID == branch.id ? 4 : 2)
+                .stroke(
+                    (selectedBranchID == branch.id || multiSelected) ? Color.white : Color.white.opacity(0.5),
+                    lineWidth: (selectedBranchID == branch.id || multiSelected) ? 4 : 2
+                )
                 .contentShape(branchPath.strokedPath(StrokeStyle(lineWidth: 20)))
                 .zIndex(2)
 
@@ -59,7 +64,10 @@ struct BranchView: View {
                     y: center.y + CGFloat(Darwin.sin(branch.angle)) * distance
                 )
 
-                NodeView(node: node, selected: selectedNodeID == node.id)
+                NodeView(
+                    node: node,
+                    selected: selectedNodeID == node.id || selectedNodeIDs.contains(node.id)
+                )
                     .position(position)
             }
 
@@ -88,6 +96,8 @@ struct BranchView: View {
         center: CGPoint(x: 150, y: 150),
         ringRadius: 100,
         selectedBranchID: .constant(nil),
-        selectedNodeID: .constant(nil)
+        selectedNodeID: .constant(nil),
+        multiSelected: false,
+        selectedNodeIDs: []
     )
 }


### PR DESCRIPTION
## Summary
- support multi-selection sets for rings, branches and nodes
- show selected state in `RingView` and `BranchView`
- implement drag selection using a transparent overlay and `DragGesture`
- draw a dashed marquee rectangle during selection
- add helper methods to clear and sync selections

## Testing
- `swift --version`
- `swift test` *(fails: could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687409c84c60832f8646d8dcd562d684