### PR TITLE
Fix flipped coordinates for macOS custom cursor

### DIFF
--- a/Ascension/Modules/Arkheion/Core/CursorOverlay.swift
+++ b/Ascension/Modules/Arkheion/Core/CursorOverlay.swift
@@ -71,6 +71,9 @@ private struct MouseTrackingView: NSViewRepresentable {
         var onMove: ((CGPoint) -> Void)?
         var onHoverChanged: ((Bool) -> Void)?
 
+        /// Use a flipped coordinate system so Y increases downward like SwiftUI.
+        override var isFlipped: Bool { true }
+
         override func updateTrackingAreas() {
             super.updateTrackingAreas()
             for area in trackingAreas { removeTrackingArea(area) }


### PR DESCRIPTION
## Summary
- use a flipped coordinate system in `TrackingNSView` so the cursor location matches SwiftUI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68745b9ff3f8832fa838a80f698ff8ac