### PR TITLE
Fix marquee selection interaction

### DIFF
--- a/Ascension/Modules/Arkheion/Core/SelectionMarqueeView.swift
+++ b/Ascension/Modules/Arkheion/Core/SelectionMarqueeView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Draws the rectangular selection marquee during drag operations.
+struct SelectionMarqueeView: View {
+    var start: CGPoint
+    var current: CGPoint
+
+    private var rect: CGRect {
+        CGRect(
+            x: min(start.x, current.x),
+            y: min(start.y, current.y),
+            width: abs(current.x - start.x),
+            height: abs(current.y - start.y)
+        )
+    }
+
+    var body: some View {
+        Rectangle()
+            .fill(Color.blue.opacity(0.15))
+            .overlay(
+                Rectangle()
+                    .strokeBorder(Color.blue,
+                                  style: StrokeStyle(lineWidth: 1, dash: [5]))
+            )
+            .frame(width: rect.width, height: rect.height)
+            .position(x: rect.midX, y: rect.midY)
+            .allowsHitTesting(false)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SelectionMarqueeView` for drag rectangle
- track drag state with `isDraggingSelection`
- ignore multi‑touch events for selection gesture
- require multi‑touch or modifier keys for canvas panning

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687460774464832fa03d3927873ce903