### PR TITLE
Improve map selection reliability

### DIFF
--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView+HitTesting.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView+HitTesting.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+/// Constants controlling hit test tolerance around map elements.
+private let nodeHitTolerance: CGFloat = 30
+private let branchHitTolerance: CGFloat = 20
+private let ringHitTolerance: CGFloat = 25
+
 extension ArkheionMapView {
     // MARK: - Coordinate Mapping
     private func convert(location: CGPoint, in geo: GeometryProxy) -> CGPoint {
@@ -48,7 +53,7 @@ extension ArkheionMapView {
         let distance = hypot(point.x - center.x, point.y - center.y)
         let angle = atan2(center.y - point.y, point.x - center.x)
         guard let ring = store.rings.min(by: { abs(distance - $0.radius) < abs(distance - $1.radius) }) else { return nil }
-        if abs(distance - ring.radius) <= 20 {
+        if abs(distance - ring.radius) <= ringHitTolerance {
             print("[ArkheionMap] ringHit -> index=\(ring.ringIndex) angle=\(angle)")
             return (ring.ringIndex, Double(angle))
         }
@@ -77,7 +82,7 @@ extension ArkheionMapView {
                     x: center.x + CGFloat(Darwin.cos(branch.angle)) * distance,
                     y: center.y + CGFloat(Darwin.sin(branch.angle)) * distance
                 )
-                let hitRadius = node.size.radius + NodeView.hitPadding
+                let hitRadius = node.size.radius + nodeHitTolerance
                 if hypot(point.x - position.x, point.y - position.y) <= hitRadius {
                     print("[ArkheionMap] hitNode -> branch=\(branch.id) node=\(node.id)")
                     return (branch.id, node.id)
@@ -102,7 +107,7 @@ extension ArkheionMapView {
                 x: origin.x + CGFloat(Darwin.cos(branch.angle)) * length,
                 y: origin.y + CGFloat(Darwin.sin(branch.angle)) * length
             )
-            if distance(from: point, toSegment: origin, end: end) <= 20 {
+            if distance(from: point, toSegment: origin, end: end) <= branchHitTolerance {
                 print("[ArkheionMap] hitBranch -> id=\(branch.id)")
                 return branch.id
             }

--- a/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
+++ b/Ascension/Modules/Arkheion/Core/ArkheionMapView.swift
@@ -229,33 +229,25 @@ struct ArkheionMapView: View {
     func handleTap(at location: CGPoint, in geo: GeometryProxy) {
         print("[ArkheionMap] Tap at \(location)")
         if let hit = hitNode(at: location, in: geo) {
-            selectedBranchID = hit.branchID
-            selectedNodeID = hit.nodeID
-            selectedRingIndex = nil
+            select(node: hit.nodeID, branch: hit.branchID)
             print("[ArkheionMap] Selected node: \(hit.nodeID)")
             return
         }
 
         if let branchID = hitBranch(at: location, in: geo) {
-            selectedBranchID = branchID
-            selectedNodeID = nil
-            selectedRingIndex = nil
+            select(branch: branchID)
             print("[ArkheionMap] Selected branch: \(branchID)")
             return
         }
 
         if let (ringIndex, _) = ringHit(at: location, in: geo) {
             highlight(ringIndex: ringIndex)
-            selectedRingIndex = ringIndex
-            selectedBranchID = nil
-            selectedNodeID = nil
+            select(ring: ringIndex)
             print("[ArkheionMap] Selected ring: \(ringIndex)")
             return
-        } else {
-            selectedRingIndex = nil
-            selectedBranchID = nil
-            selectedNodeID = nil
         }
+
+        clearSelection()
     }
 
     func handleDoubleTap(at location: CGPoint, in geo: GeometryProxy) {
@@ -291,6 +283,25 @@ struct ArkheionMapView: View {
                 highlightedRingIndex = nil
             }
         }
+    }
+
+    // MARK: - Selection Helpers
+    func select(node: UUID, branch: UUID) {
+        selectedNodeID = node
+        selectedBranchID = branch
+        selectedRingIndex = nil
+    }
+
+    func select(branch: UUID) {
+        selectedBranchID = branch
+        selectedNodeID = nil
+        selectedRingIndex = nil
+    }
+
+    func select(ring: Int) {
+        selectedRingIndex = ring
+        selectedBranchID = nil
+        selectedNodeID = nil
     }
 
     func clearSelection() {


### PR DESCRIPTION
## Summary
- add configurable hit tolerances for nodes, branches and rings
- add `select` helpers for ring, branch and node selection
- prioritize hits in `handleTap` and clear selection on miss

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6875d1c1b59c832fae20e0122026e274