### PR TITLE
Simplify Arkheion tap handling

### DIFF
--- a/Ascension/Modules/Arkheion/Core/RingView.swift
+++ b/Ascension/Modules/Arkheion/Core/RingView.swift
@@ -17,6 +17,7 @@ struct RingView: View {
     var center: CGPoint
     var highlighted: Bool = false
     var selected: Bool = false
+    var onTap: (() -> Void)? = nil
 
     private var strokeColor: Color {
         ring.locked ? Color.white.opacity(0.2) : Color.white.opacity(0.4)
@@ -43,6 +44,9 @@ struct RingView: View {
         .shadow(color: ring.locked ? .clear : Color.white.opacity(0.5), radius: ring.locked ? 0 : 4)
         .contentShape(Rectangle())
         .allowsHitTesting(true)
+        .onTapGesture {
+            onTap?()
+        }
     }
 }
 

--- a/Ascension/Modules/Arkheion/Editor/BranchView.swift
+++ b/Ascension/Modules/Arkheion/Editor/BranchView.swift
@@ -6,6 +6,7 @@ struct BranchView: View {
     var center: CGPoint
     var ringRadius: CGFloat
     @Binding var selectedBranchID: UUID?
+    var onTap: (() -> Void)? = nil
 
     var body: some View {
         // Starting point of the branch at the ring's edge
@@ -37,6 +38,9 @@ struct BranchView: View {
         }
         .contentShape(Rectangle())
         .allowsHitTesting(true)
+        .onTapGesture {
+            onTap?()
+        }
         .zIndex(1)
     }
 }


### PR DESCRIPTION
## Summary
- switch `RingView` and `BranchView` to use `.onTapGesture`
- update `ArkheionMapView` selection helpers and state
- replace obsolete precision gesture with a hover gesture and double-tap detector

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688005ef2f98832f9251c8c6cb5307d3